### PR TITLE
Ramp colors

### DIFF
--- a/client/controllers/bioevent.js
+++ b/client/controllers/bioevent.js
@@ -184,7 +184,7 @@ Template.bioevent.onRendered(function() {
               }).addTo(map);
               layer.setStyle({
                 weight: 2,
-                color: Constants.PRIMARY_COLOR
+                color: Constants.OUTBOUND_COLOR
               });
               window.setTimeout(()=>{
                 marker.resetStyle(layer);

--- a/client/controllers/bioevent.js
+++ b/client/controllers/bioevent.js
@@ -81,7 +81,7 @@ Template.bioevent.onRendered(function() {
         return {
           fillColor: value ? getColor(0.8 * value / maxValue, this.ramp) : '#FFFFFF',
           weight: 1,
-          color: this.ramp[9],
+          color: getColor(1, this.ramp),
           // Hide the US since it will be shown in the states layer.
           fillOpacity: feature.properties.iso_a2 == 'US' ? 0.0 : 1.0
         };
@@ -151,7 +151,7 @@ Template.bioevent.onRendered(function() {
           return {
             fillColor: value && (location.type === 'airport' || showChoropleth) ? getColor(0.8 * value / maxValue, this.ramp) : '#FFFFFF',
             weight: 1,
-            color: this.ramp[9],
+            color: getColor(1, this.ramp),
             fillOpacity: 1.0
           };
         },
@@ -184,7 +184,7 @@ Template.bioevent.onRendered(function() {
               }).addTo(map);
               layer.setStyle({
                 weight: 2,
-                color: Constants.OUTBOUND_COLOR
+                color: getColor(1, this.ramp),
               });
               window.setTimeout(()=>{
                 marker.resetStyle(layer);

--- a/client/controllers/splash.js
+++ b/client/controllers/splash.js
@@ -156,7 +156,7 @@ Template.splash.onRendered(function() {
               }).addTo(map);
               layer.setStyle({
                 weight: 2,
-                color: Constants.PRIMARY_COLOR
+                color: Constants.OUTBOUND_COLOR
               });
               window.setTimeout(()=>{
                 marker.resetStyle(layer);

--- a/client/controllers/splash.js
+++ b/client/controllers/splash.js
@@ -67,7 +67,7 @@ Template.splash.onRendered(function() {
         return {
           fillColor: value ? getColor(0.8 * value / maxValue, INBOUND_RAMP) : '#FFFFFF',
           weight: 1,
-          color: INBOUND_RAMP[9],
+          color: getColor(1, INBOUND_RAMP),
           // Hide the US since it will be shown in the states layer.
           fillOpacity: feature.properties.iso_a2 == 'US' ? 0.0 : 1.0
         };
@@ -123,7 +123,7 @@ Template.splash.onRendered(function() {
           return {
             fillColor: value && (location.type === 'airport' || showChoropleth) ? getColor(0.8 * value / maxValue, INBOUND_RAMP) : '#FFFFFF',
             weight: 1,
-            color: INBOUND_RAMP[9],
+            color: getColor(1, INBOUND_RAMP),
             fillOpacity: 1.0
           };
         },
@@ -156,7 +156,7 @@ Template.splash.onRendered(function() {
               }).addTo(map);
               layer.setStyle({
                 weight: 2,
-                color: Constants.OUTBOUND_COLOR
+                color: getColor(1, OUTBOUND_RAMP),
               });
               window.setTimeout(()=>{
                 marker.resetStyle(layer);

--- a/client/imports/stylesheets/map.import.styl
+++ b/client/imports/stylesheets/map.import.styl
@@ -43,11 +43,11 @@
   font-size 0.85em
   .title
     margin-top -5px
-    max-width 200px
+    max-width 225px
   .values
     border 1px solid gray
     line-height 0
   .value
     height 10px
-    width 20px
+    width 25px
     display inline-block

--- a/imports/constants.js
+++ b/imports/constants.js
@@ -1,6 +1,4 @@
 module.exports = {
   MILLIS_PER_DAY: 60 * 60 * 24 * 1000,
   DATA_INTERVAL_DAYS: 14,
-  OUTBOUND_COLOR: "#b1001c",
-  INBOUND_COLOR: "#1c00b1",
 };

--- a/imports/constants.js
+++ b/imports/constants.js
@@ -1,5 +1,6 @@
 module.exports = {
   MILLIS_PER_DAY: 60 * 60 * 24 * 1000,
   DATA_INTERVAL_DAYS: 14,
-  PRIMARY_COLOR: "#a10000"
+  OUTBOUND_COLOR: "#b1001c",
+  INBOUND_COLOR: "#1c00b1",
 };

--- a/imports/ramps.js
+++ b/imports/ramps.js
@@ -1,7 +1,7 @@
 import Constants from '/imports/constants';
 module.exports = {
-    OUTBOUND_RAMP: chroma.scale(["#ffffff", Constants.PRIMARY_COLOR]).colors(10),
-    INBOUND_RAMP: chroma.scale(["#ffffff", "#0000ff"]).colors(10),
+    OUTBOUND_RAMP: chroma.scale(["#ffffff", Constants.OUTBOUND_COLOR]).colors(10),
+    INBOUND_RAMP: chroma.scale(["#ffffff", Constants.INBOUND_COLOR]).colors(10),
     getColor: (val, ramp) => {
       //return a color from the ramp based on a 0 to 1 value.
       //If the value exceeds one the last stop is used.

--- a/imports/ramps.js
+++ b/imports/ramps.js
@@ -1,7 +1,6 @@
-import Constants from '/imports/constants';
 module.exports = {
-    OUTBOUND_RAMP: chroma.scale(["#ffffff", Constants.OUTBOUND_COLOR]).colors(10),
-    INBOUND_RAMP: chroma.scale(["#ffffff", Constants.INBOUND_COLOR]).colors(10),
+    OUTBOUND_RAMP: chroma.brewer.Reds,
+    INBOUND_RAMP: chroma.brewer.Blues,
     getColor: (val, ramp) => {
       //return a color from the ramp based on a 0 to 1 value.
       //If the value exceeds one the last stop is used.


### PR DESCRIPTION
Updated color ramps to use ColorBrewer ramps. These are built into `chroma`, which made it kinda simple.

- Because of this, I removed the OUTBOUND_COLOR variables and references; wherever those were used. we now use `getColor(1, ramp)`.
- There were also some instances where the color was specified with a fixed reference to an index in the ramp. Since ColorBrewer ramps are shorter, I also replaced those with `getColor(1, ramp)`.

There is one place where this isn't working correctly. On the Bioevent page, the Outbound Threat Level ramp shows correctly, but the Estimated Probability Passenger Infected ramp doesn't. Screenshots are attached.

<img width="216" alt="screen shot 2018-08-17 at 11 58 57 am" src="https://user-images.githubusercontent.com/3117884/44276644-1cbe1680-a216-11e8-8544-40ac403d627f.png">
<img width="235" alt="screen shot 2018-08-17 at 11 59 04 am" src="https://user-images.githubusercontent.com/3117884/44276645-1cbe1680-a216-11e8-83fb-957e2c4012bd.png">
